### PR TITLE
Add Cloudflare workers Kimi K2.6 grammar leak parsers + AI model detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,13 @@ Repair rules apply to pi's built-in tools: `read`, `write`, `edit`, `bash`, `gre
 
 Phase 0 schema sanitization activates for models matching these patterns:
 
-| Pattern      | Models           |
-| ------------ | ---------------- |
-| `/kimi-k2/i` | Kimi K2 variants |
-| `/minimax/i` | MiniMax variants |
-| `/glm/i`     | GLM variants     |
+| Pattern           | Models                              |
+| ----------------- | ----------------------------------- |
+| `/kimi-k2/i`      | Kimi K2 variants                    |
+| `/moonshotai\/kimi/i` | Moonshot Kimi (direct API)      |
+| `/@cf\/.*kimi/i`  | @cf Kimi (e.g. `@cf/moonshotai/kimi-k2.6`) |
+| `/minimax/i`      | MiniMax variants                    |
+| `/glm/i`          | GLM variants                        |
 
 To add more models, edit `anchorBleedModels` in [`src/index.ts`](./src/index.ts).
 

--- a/__tests__/grammar-repair.test.ts
+++ b/__tests__/grammar-repair.test.ts
@@ -23,6 +23,7 @@ const enabledConfig: GrammarRepairConfig = {
   mode: "recover",
   requireKnownTool: true,
   debug: false,
+
 };
 
 describe("grammar leak parsing", () => {
@@ -104,6 +105,72 @@ describe("grammar leak parsing", () => {
     expect(calls).toEqual([
       { grammar: "kimi", name: "first", arguments: { a: 1 } },
       { grammar: "kimi", name: "second", arguments: { b: 2 } },
+    ]);
+  });
+
+  it("parses Kimi console tool_call closed only by redacted_thinking", () => {
+    const text = ` <tool_call> {"name": "bash", "arguments": {"command":"test"}}</${"redacted_thinking"}>`;
+    expect(parseToolGrammarLeaks(text, ["kimi"])).toEqual([
+      { grammar: "kimi", name: "bash", arguments: { command: "test" } },
+    ]);
+  });
+
+  it("strips dangling Kimi tool_call open markers", () => {
+    const result = repairAssistantMessageGrammarLeaks(
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I'll run this.\n<tool_call>\n" }],
+        stopReason: "stop",
+      },
+      { ...enabledConfig, grammars: ["kimi"] },
+      new Set(["bash"]),
+    );
+    expect(result.changed).toBe(true);
+    expect(result.recoveredCalls).toEqual([]);
+    expect((result.message.content[0] as { text: string }).text).toBe("I'll run this.");
+  });
+
+  it("strips truncated Kimi sentinel markers", () => {
+    const result = repairAssistantMessageGrammarLeaks(
+      {
+        role: "assistant",
+        content: [{
+          type: "text",
+          text: "prefix\n<|tool_calls_section_begin|><|tool_call_begin|>functions.read:0",
+        }],
+        stopReason: "stop",
+      },
+      { ...enabledConfig, grammars: ["kimi"] },
+      new Set(["read"]),
+    );
+    expect(result.changed).toBe(true);
+    expect(result.recoveredCalls).toEqual([]);
+    expect((result.message.content[0] as { text: string }).text).toBe("prefix");
+  });
+
+  it("recovers Kimi K2.6 session-style duplicate-close tool_call leaks", () => {
+    const text = `<tool_call>
+{"name": "bash", "arguments": {"command":"cd /tmp && grep -l 'tool_call' *.ts"}}"</tool_call>
+</tool_call>`;
+    const result = repairAssistantMessageGrammarLeaks(
+      {
+        role: "assistant",
+        content: [{ type: "text", text }],
+        stopReason: "stop",
+      },
+      enabledConfig,
+      new Set(["bash"]),
+    );
+    expect(result.changed).toBe(true);
+    expect(result.message.stopReason).toBe("toolUse");
+    expect(result.message.content).toEqual([
+      { type: "text", text: "" },
+      {
+        type: "toolCall",
+        id: expect.stringMatching(/^tool_repair_/),
+        name: "bash",
+        arguments: { command: "cd /tmp && grep -l 'tool_call' *.ts" },
+      },
     ]);
   });
 
@@ -375,3 +442,5 @@ describe("assistant message grammar repair", () => {
     expect((result.message.content[0] as { text: string }).text).toBe("prefix");
   });
 });
+
+

--- a/__tests__/unit/tool-repair.test.ts
+++ b/__tests__/unit/tool-repair.test.ts
@@ -117,7 +117,9 @@ describe("stripAnchorBleedInPlace", () => {
 });
 
 describe("hasAnchorBleedBug", () => {
-  it("detects kimi-k2 models", () => {
+  it("detects @cf kimi model ids", () => {
+    expect(hasAnchorBleedBug({ id: "@cf/moonshotai/kimi-k2.6" })).toBe(true);
+    expect(hasAnchorBleedBug({ id: "@cf/other/kimi-preview" })).toBe(true);
     expect(hasAnchorBleedBug({ id: "kimi-k2-instruct" })).toBe(true);
   });
 

--- a/src/grammar-repair.ts
+++ b/src/grammar-repair.ts
@@ -113,6 +113,7 @@ export function defaultConfigPath(): string {
   return join(getAgentDir(), "extensions", "pi-tool-repair.json");
 }
 
+
 export function normalizeGrammarRepairConfig(raw: Partial<GrammarRepairConfig> = {}): GrammarRepairConfig {
   const grammarSet = new Set<GrammarName>(ALL_GRAMMARS);
   const grammars = Array.isArray(raw.grammars)
@@ -234,6 +235,9 @@ function parseToolGrammarCandidates(text: string, enabled: Set<GrammarName>): Ca
     candidates.push(...parseDsmlDanglingMarkers(text));
   }
   if (enabled.has("kimi")) candidates.push(...parseKimi(text));
+  if (enabled.has("qwen") || enabled.has("granite") || enabled.has("kimi")) {
+    candidates.push(...parseOrphanToolCallClosers(text));
+  }
   if (enabled.has("mistral")) {
     candidates.push(...parseMistral(text));
     candidates.push(...parseBareJsonToolCalls(text, "mistral"));
@@ -378,6 +382,138 @@ function parseKimi(text: string): Candidate[] {
         range: { start: sectionStart, end: sectionStart + section[0].length },
       });
     }
+  }
+
+  candidates.push(...parseKimiLooseToolCallXml(text));
+  candidates.push(...parseKimiDanglingMarkers(text));
+  return candidates;
+}
+
+function parseKimiLooseToolCallXml(text: string): Candidate[] {
+  const candidates: Candidate[] = [];
+  const openRe = /<tool_call>/gi;
+
+  for (const match of text.matchAll(openRe)) {
+    if (match.index === undefined || isInsideCodeFence(text, match.index)) continue;
+
+    const start = match.index;
+    const bodyStart = start + match[0].length;
+    if (findPattern(text, /<\/tool_call>/gi, bodyStart)) continue;
+
+    const looseClose = findPattern(
+      text,
+      /<\/(?:redacted_thinking|thinking)>/gi,
+      bodyStart,
+    );
+    if (!looseClose) continue;
+
+    const body = text.slice(bodyStart, looseClose.start);
+    for (const call of parseToolCallJsonBody(body, "kimi")) {
+      candidates.push({ ...call, range: { start, end: looseClose.end } });
+    }
+  }
+
+  return candidates;
+}
+
+function parseKimiDanglingMarkers(text: string): Candidate[] {
+  const candidates: Candidate[] = [];
+  const sectionOpenRe = /<\|(?:redacted_)?tool_calls?_section_begin\|>/gi;
+
+  for (const match of text.matchAll(sectionOpenRe)) {
+    if (match.index === undefined || isInsideCodeFence(text, match.index)) continue;
+    const sectionStart = match.index;
+    if (findPattern(text, /<\|(?:redacted_)?tool_calls?_section_end\|>/gi, sectionStart)) continue;
+
+    const end = findBestKimiUnclosedEnd(text, sectionStart + match[0].length) ?? sectionStart + match[0].length;
+    candidates.push({
+      name: "",
+      arguments: {},
+      grammar: "kimi",
+      range: { start: sectionStart, end },
+      stripOnly: true,
+    });
+  }
+
+  const openRe = /<tool_call>/gi;
+  for (const match of text.matchAll(openRe)) {
+    if (match.index === undefined || isInsideCodeFence(text, match.index)) continue;
+    const start = match.index;
+    const bodyStart = start + match[0].length;
+    const strictClose = findPattern(text, /<\/tool_call>/gi, bodyStart);
+    const looseClose = findPattern(text, /<\/(?:redacted_thinking|thinking)>/gi, bodyStart);
+    const close = strictClose ?? looseClose;
+    if (close && parseToolCallJsonBody(text.slice(bodyStart, close.start), "kimi").length > 0) continue;
+
+    candidates.push({
+      name: "",
+      arguments: {},
+      grammar: "kimi",
+      range: { start, end: close?.end ?? bodyStart },
+      stripOnly: true,
+    });
+  }
+
+  const markerRe = /<\|(?:redacted_)?tool_call(?:s)?(?:_section)?_(?:begin(?:_kimi)?|argument_begin|end(?:_kimi)?)\|>/gi;
+  for (const match of text.matchAll(markerRe)) {
+    if (match.index === undefined || isInsideCodeFence(text, match.index)) continue;
+    const range = { start: match.index, end: match.index + match[0].length };
+    if (candidates.some((candidate) => rangesOverlap(candidate.range, range))) continue;
+    candidates.push({
+      name: "",
+      arguments: {},
+      grammar: "kimi",
+      range,
+      stripOnly: true,
+    });
+  }
+
+  return candidates;
+}
+
+function findBestKimiUnclosedEnd(text: string, from: number): number | undefined {
+  const markerRe = /<\|(?:redacted_)?tool_call(?:s)?(?:_section)?_(?:begin(?:_kimi)?|argument_begin|end(?:_kimi)?)\|>/gi;
+  markerRe.lastIndex = from;
+  let end: number | undefined;
+  for (;;) {
+    const match = markerRe.exec(text);
+    if (!match) break;
+    end = match.index + match[0].length;
+  }
+  if (end === undefined) return undefined;
+
+  const tail = text.slice(end);
+  const idMatch = /^\s*functions\.[A-Za-z_][\w.-]*:\d*/.exec(tail);
+  if (idMatch) end += idMatch[0].length;
+
+  const argMarker = findPattern(text, /<\|(?:redacted_)?tool_call_argument_begin\|>/gi, end);
+  if (argMarker) {
+    end = argMarker.end;
+    const json = extractFirstBalancedJson(text.slice(end));
+    if (json) end += json.end;
+  }
+
+  return end;
+}
+
+function parseOrphanToolCallClosers(text: string): Candidate[] {
+  const candidates: Candidate[] = [];
+  const closeRe = /<\/tool_call>\s*/gi;
+
+  for (const match of text.matchAll(closeRe)) {
+    if (match.index === undefined || isInsideCodeFence(text, match.index)) continue;
+    const before = text.slice(0, match.index);
+    const opens = before.match(/<tool_call>/gi)?.length ?? 0;
+    const closes = before.match(/<\/tool_call>/gi)?.length ?? 0;
+    if (opens > closes) continue;
+
+    candidates.push({
+      name: "",
+      arguments: {},
+      grammar: "kimi",
+      range: { start: match.index, end: match.index + match[0].length },
+      stripOnly: true,
+    });
   }
 
   return candidates;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,9 @@ export interface RepairConfig {
 export const DEFAULT_CONFIG: RepairConfig = {
   debug: Boolean(process.env.PI_TOOL_REPAIR_DEBUG),
   anchorBleedModels: [
-    /kimi-k2/i,
+    /kimi[-_]?k2/i,
+    /moonshotai\/kimi/i,
+    /@cf\/.*kimi/i,
     /minimax/i,
     /glm/i,
   ],

--- a/tool-repair.ts
+++ b/tool-repair.ts
@@ -216,7 +216,7 @@ export default function (pi: ExtensionAPI) {
 
     if (!result.changed && !toolCallArgsChanged) return;
 
-    if (grammarRepairConfig.debug && result.changed) {
+    if (grammarRepairConfig.debug) {
       const calls = result.recoveredCalls.map((call) => `${call.grammar}:${call.name}`).join(",") || "none";
       process.stderr.write(
         `[pi-tool-repair] grammar-repair mode=${grammarRepairConfig.mode} ` +


### PR DESCRIPTION
This pull request is draft because it's mostly vibe-coded and it probably shouldn't be merged as-is. 
Long story short, I got access to `@cf/moonshotai/kimi-k2.6`, where `@cf` stands for cloudflare workers and ai gateway. This version of model has a lot of weird tool call breakages. This draft PR fixes an additional bunch of them, so it's almost usable, but still sometimes breaks.

Changes:

- Update anchorBleedModels regex to detect "@cf/moonshotai/kimi-k2.6" and other Kimi variants
- Add Kimi-specific grammar leak parsers in src/grammar-repair.ts:
  * parseKimiLooseToolCallXml - handles </redacted_thinking> closures
  * parseKimiDanglingMarkers - strips dangling <\|tool_calls_section_begin|>
  * parseOrphanToolCallClosers - handles orphaned </tool_call> markers
  * findBestKimiUnclosedEnd - finds Kimi-specific end markers
- Add comprehensive tests for cfbt/K2.6-specific leak patterns
- Revert autoEnableForKimi flag to manual-only configuration

The parsers handle the unique grammar leakage quirks of Cloudflare Workers AI Kimi K2.6 (e.g., @cf/moonshotai/kimi-k2.6), including truncated sentinels, duplicate-close session-style leaks, and MDAXML-style tool_call markers.